### PR TITLE
adds virtual keyboard on mobile

### DIFF
--- a/wordle.js
+++ b/wordle.js
@@ -25,6 +25,18 @@ function drawGrid() {
         }
         main.appendChild(row);
     }
+
+    // Check if the device is a mobile device
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+    // If it's a mobile device, set focus on the first item in the grid
+    if (isMobile) {
+        const firstGridItem = document.getElementById('r0c0');
+        if (firstGridItem) {
+            firstGridItem.setAttribute('tabindex', '0');
+            firstGridItem.focus();
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
This change resolves #1 by adding a virtual keyboard when the user is on mobile. I could not test the feature that well but setting a focus to the first item in the grid should force the keyboard open.
Signed-off-by: Jason Zubiate <jasonzubiate.com>